### PR TITLE
Support custom hint text size

### DIFF
--- a/library/src/main/java/fr/ganfra/materialspinner/MaterialSpinner.java
+++ b/library/src/main/java/fr/ganfra/materialspinner/MaterialSpinner.java
@@ -579,6 +579,15 @@ public class MaterialSpinner extends AppCompatSpinner implements ValueAnimator.A
         invalidate();
     }
 
+    public float getHintTextSize() {
+        return hintTextSize;
+    }
+
+    public void setHintTextSize(float hintTextSize) {
+        this.hintTextSize = hintTextSize;
+        invalidate();
+    }
+
     public int getErrorColor() {
         return errorColor;
     }

--- a/library/src/main/java/fr/ganfra/materialspinner/MaterialSpinner.java
+++ b/library/src/main/java/fr/ganfra/materialspinner/MaterialSpinner.java
@@ -88,6 +88,7 @@ public class MaterialSpinner extends AppCompatSpinner implements ValueAnimator.A
     private CharSequence error;
     private CharSequence hint;
     private int hintColor;
+    private float hintTextSize;
     private CharSequence floatingLabelText;
     private int floatingLabelColor;
     private boolean multiline;
@@ -162,6 +163,7 @@ public class MaterialSpinner extends AppCompatSpinner implements ValueAnimator.A
         error = array.getString(R.styleable.MaterialSpinner_ms_error);
         hint = array.getString(R.styleable.MaterialSpinner_ms_hint);
         hintColor = array.getColor(R.styleable.MaterialSpinner_ms_hintColor, baseColor);
+        hintTextSize = array.getDimension(R.styleable.MaterialSpinner_ms_hintTextSize, -1);
         floatingLabelText = array.getString(R.styleable.MaterialSpinner_ms_floatingLabelText);
         floatingLabelColor = array.getColor(R.styleable.MaterialSpinner_ms_floatingLabelColor, baseColor);
         multiline = array.getBoolean(R.styleable.MaterialSpinner_ms_multiline, true);
@@ -813,6 +815,8 @@ public class MaterialSpinner extends AppCompatSpinner implements ValueAnimator.A
             textView.setText(hint);
             textView.setTextColor(MaterialSpinner.this.isEnabled() ? hintColor : disabledColor);
             textView.setTag(HINT_TYPE);
+            if (hintTextSize != -1)
+                textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, hintTextSize);
             return textView;
         }
 

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -7,6 +7,7 @@
         <attr name="ms_error" format="string"/>
         <attr name="ms_hint" format="string"/>
         <attr name="ms_hintColor" format="color"/>
+        <attr name="ms_hintTextSize" format="dimension"/>
         <attr name="ms_floatingLabelText" format="string"/>
         <attr name="ms_floatingLabelColor" format="color"/>
         <attr name="ms_multiline" format="boolean"/>


### PR DESCRIPTION
Customizable with `ms_hintTextSize`.
This is usefull when you use custom `spinner_item` with smaller text size. 